### PR TITLE
Fix RuboCop errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 group :development, :test do

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'pg_failover'

--- a/lib/pg_failover.rb
+++ b/lib/pg_failover.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PgFailover
   autoload :ActiveRecordAdapter, 'pg_failover/active_record_adapter'
   autoload :Config, 'pg_failover/config'

--- a/pg_failover.gemspec
+++ b/pg_failover.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |spec|
   spec.name          = 'pg_failover'
   spec.version       = '1.0.0'

--- a/spec/pg_failover/active_record_adapter_spec.rb
+++ b/spec/pg_failover/active_record_adapter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'active_record'
 require 'active_record/connection_adapters/postgresql_adapter'

--- a/spec/pg_failover/config_spec.rb
+++ b/spec/pg_failover/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'pg_failover'
 

--- a/spec/pg_failover/connection_validator_spec.rb
+++ b/spec/pg_failover/connection_validator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'pg_failover'
 

--- a/spec/pg_failover/sequel_adapter_spec.rb
+++ b/spec/pg_failover/sequel_adapter_spec.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 begin
   require 'sequel'
-rescue LoadError => _
+rescue LoadError => _e
 end
 require 'pg_failover'
 

--- a/spec/pg_failover/throttle_spec.rb
+++ b/spec/pg_failover/throttle_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'pg_failover'
 

--- a/spec/pg_failover_spec.rb
+++ b/spec/pg_failover_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'active_record'
 require 'active_record/connection_adapters/postgresql_adapter'
 begin
   require 'sequel'
-rescue LoadError => _
+rescue LoadError => _e
 end
 require 'pg_failover'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'pg_failover'
 


### PR DESCRIPTION
💁 Corrects a few lingering RuboCop failures through running `bundle exec rubocop --auto-correct` and committing the changes.