### PR TITLE
Fix gem publish from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
   publish:
     executor:
       name: ruby
+      tag: "3.0"
     steps:
       - checkout
       - install-dependencies
@@ -111,3 +112,4 @@ workflows:
             - ruby25
             - ruby26
             - ruby27
+            - ruby30


### PR DESCRIPTION
Use the `cimg/ruby:3.0` image as there is no latest image